### PR TITLE
Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Welcome to the Defcon Arsenal Tool ([DArT](https://github.com/Defcon-Parrot/DArT))! This repository aims to provide a comprehensive collection of tools and resources for security professionals and enthusiasts attending the DEFCON conference. In this README, you will find information on how to contribute to the project and help make it better.
 
-![DEFCON Arsenal Tools](https://user-images.githubusercontent.com/30528167/194520228-1c8422f0-5e25-4d71-8d41-4a1f05c11252.png)
+![DEFCON Arsenal Tools](https://github.com/DefconParrot/DefconArsenalTools/assets/30528167/ccd2ac91-2557-436a-80d6-6ce280c9f05b)
+
 Current Update: <b><i>DC1 - DC31</i></b>
 Repo aims to improve this DC page -> [Tools](https://defcon.org/html/links/dc-tools.html)
 
@@ -155,9 +156,8 @@ If you have any questions or need further assistance, don't hesitate to reach ou
 
 ## Contact Us (Twitter)
 
-- Defcon Parrot => [Get in touch](https://twitter.com/DefconParrot)
-- DefconGroups => [Get in touch](https://twitter.com/defcongroups)
-- Defcon Conference => [Get in touch](https://twitter.com/defcon)
+- Curator => Get in touch: [𝕏: @DefconParrot↗](https://twitter.com/DefconParrot)
+- Defcon => Get in touch: [𝕏: @defcon↗](https://twitter.com/defcon) | [Mastodon: @defcon↗](https://defcon.social/@defcon) | [defcon.org](http://defcon.org)
 
 ## License
 

--- a/exploitation/DC30/emoji_shellcoding.md
+++ b/exploitation/DC30/emoji_shellcoding.md
@@ -13,7 +13,8 @@ Shellcodes are short executable stubs that are used in various attack scenarios,
 ## Reference Links:
 - Link to Tool => https://github.com/RischardV/emoji-shellcoding
 - Link to slide => https://media.defcon.org/DEF%20CON%2030/DEF%20CON%2030%20presentations/Hadrien%20Barral%20-%20Emoji%20Shellcoding.pdf
-- Link to Talk(presentation) => video Coming soon! => [additional description](https://forum.defcon.org/node/241820)
+- Link to Talk(presentation) => [https://youtu.be/E8puAkalMRQ](https://youtu.be/E8puAkalMRQ) 
+- [Additional description](https://forum.defcon.org/node/241820)
 
 ## Author BIO(S):
 - *Hadrien Barral* is an R&D engineer and security expert, focusing on intrusion and high-assurance software. He enjoys hacking on exotic hardware.

--- a/toolsAdded.md
+++ b/toolsAdded.md
@@ -1,0 +1,17 @@
+ctrl + F => Easily check if a tool you intend to add has been already added / or for the purpose of information update on a particular tool.
+
+|   Tool Name           | Addition Status: Done / In Progress  |
+|-----------------------|--------------------------------------|
+| [EDRSandBlast](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC30/EDRSandBlast.md)          |      Done                            |
+| [cisco_asa_research](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC30/cisco_asa_research.md)    |      Done                            |
+| [emoji_shellcoding](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC30/emoji_shellcoding.md)     |      Done                            |
+| [pacman](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC30/pacman.md) | Done |
+| [powerpwn](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC30/powerpwn.md) | Done |
+| [FRAK](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC20/FRAK.md) | Done |
+| [TeamFiltration](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC30/TeamFiltration.md) | Done |
+| [canTot](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC30/canTot.md) | Done |
+| [EMBA](https://github.com/DefconParrot/DefconArsenalTools/blob/main/hardening/EMBA.md) | Done |
+| [Gatekeyper](https://github.com/DefconParrot/DefconArsenalTools/blob/main/lock_picking/DC26/Gatekeyper.md) | Done |
+| [BULA-Virus](https://github.com/DefconParrot/DefconArsenalTools/blob/main/malware_research/DC30/BULA-Virus.md) | Done |
+| [CANalyse](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_attacks/DC30/CANalyse.md) | Done |
+| [SquarePhish](https://github.com/DefconParrot/DefconArsenalTools/blob/main/phishing/DC30/SquarePhish.md) | Done |


### PR DESCRIPTION
Minor Updates:
- Video link addition for the `emoji_shellcoding` talk at DEF CON.
- Defcon's Mastodon link addition.

Additions
- `toolsAdded` file to act as a stop over. Before adding a new tool, you can first of all check if it is already added to avoid duplication without the hustle of going folder by folder to check its existence. 