### PR TITLE
broken link update

### DIFF
--- a/toolsAdded.md
+++ b/toolsAdded.md
@@ -1,54 +1,54 @@
 ctrl + F => Easily check if a tool you intend to add has been already added / or for the purpose of information update on a particular tool.
 
-|   Tool Name           | Addition Status: Added / In Progress                    |
-|-----------------------|---------------------------------------------------------|
-| [EDRSandBlast](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC30/EDRSandBlast.md) |      Added |
-| [cisco_asa_research](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC30/cisco_asa_research.md) | Added  |
-| [emoji_shellcoding](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC30/emoji_shellcoding.md)     |      Added                            |
-| [pacman](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC30/pacman.md) | Added |
-| [powerpwn](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC30/powerpwn.md) | Added |
-| [FRAK](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC20/FRAK.md) | Added |
-| [TeamFiltration](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC30/TeamFiltration.md) | Added |
-| [canTot](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC30/canTot.md) | Added |
-| [EMBA](https://github.com/DefconParrot/DefconArsenalTools/blob/main/hardening/DC30/EMBA.md) | Added |
-| [Gatekeyper](https://github.com/DefconParrot/DefconArsenalTools/blob/main/lock_picking/DC26/Gatekeyper.md) | Added |
-| [BULA-Virus](https://github.com/DefconParrot/DefconArsenalTools/blob/main/malware_research/DC30/BULA-Virus.md) | Added |
-| [CANalyse](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_attacks/DC30/CANalyse.md) | Added |
-| [SquarePhish](https://github.com/DefconParrot/DefconArsenalTools/blob/main/phishing/DC30/SquarePhish.md) | Added |
-| [WiGLEBottleV2](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency/DC31/BT-BLE/AppleJuice.md) | Added |
-| [AppleJuice](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency/DC31/wardriving/RPi4_WigleBottle_v2.md) | Added |
-| [WIFISHARK](<https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency/DC31/802.11 WIFI/WIFISHARK.md>) | Added |
-| [Veilid](https://github.com/DefconParrot/DefconArsenalTools/blob/main/P2P/DC31/Veilid.md) | Added |
-| [Wifydra](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency/DC31/wardriving/The_Wifydra.md) | Added |
-| [WiGLE Balloon](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency/DC31/wardriving/Wigle_Balloon.md) | Added |
-| [RFparty](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency/DC31/802.11%WIFI/rfparty-xyz.md) | Added |
-| [CloudRecon](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_analysis/DC31/CloudRecon.md) | Added |
-| [EasyEASM](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC31/EasyEASM.md) | Added |
-| [asyauth](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_attacks/DC31/asyauth.md) | Added |
-| [SpamChannel](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC31/SpamChannel.md) | Added  |
-| [ezviz_lan_rce](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_attacks/DC31/ezviz_lan_rce.md) |Added |
-| [RelocBonus](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC26/RelocBonus.md) | Added  |
-| [NoFilter](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC31/NoFilter.md) | Added  |
-| [ContainYourself](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC31/ContainYourself.md) | Added  |
-| [RTV Secure Terminal CTF](https://github.com/DefconParrot/DefconArsenalTools/blob/main/CTF/DC31/RTV_Secure_Terminal_CTF.md) | Added | 
-| [Hack to Basics](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC27/Hack%20to%20Basics.md) | Added | 
-| [Starkiller](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC28/Starkiller.md) | Added | 
-| [Empire](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC30/Empire.md) | Added | 
-| [Long Live the Empire](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC31/Long_Live_the_Empire.md) | Added | 
-| [Hacking Bluetooth Low Energy Locks](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency/DC24/Hacking_BLE_Locks.md) | Added | 
-| [CrackMapExec](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_attacks/DC24/CrackMapExec.md) | Added |
-| [OPC-UA](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC31/OPC-UA.md) | Added |
-| [git-wild-hunt](https://github.com/DefconParrot/DefconArsenalTools/blob/main/credential_scanning/DC29/git-wild-hunt.md) | Added |
-| [Katalina](https://github.com/DefconParrot/DefconArsenalTools/blob/main/malware_research/DC31/Katalina.md) | Added |
-| [Wine_Pairing_with_Malware](https://github.com/DefconParrot/DefconArsenalTools/blob/main/malware_research/DC31/Wine_Pairing_with_Malware.md) | Added |
-| [Evasion](https://github.com/DefconParrot/DefconArsenalTools/blob/main/Evasion/DC30/AceLdr.md) | Added |
-| [Ensemble](https://github.com/DefconParrot/DefconArsenalTools/blob/main/uncategorized/DC31/Ensemble.md) | Added |
-| [BrokenbyDesign](https://github.com/DefconParrot/DefconArsenalTools/blob/main/Cloud/DC30/brokenbydesign-azure.md) | Added |
-| [AzureGoat](https://github.com/DefconParrot/DefconArsenalTools/blob/main/Cloud/DC30/AzureGoat.md) | Added |
-| [BLEMystique](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency/DC26/BLEMystique.md) | Added |
-| [VoIPShark](https://github.com/DefconParrot/DefconArsenalTools/blob/mainnetwork_analysis/DCChina1/VoIPShark.md) | Added |
-| [Zfone](https://github.com/DefconParrot/DefconArsenalTools/blob/mainnetwork_analysis/Telephony/DC15/zphone.md) | Added |
-| [guestlist](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC31/guestlist.md) | Added |
-| [FuncoPop](https://github.com/DefconParrot/DefconArsenalTools/blob/main/Cloud/DC31/FuncoPop.md) | Added |
-| [akto](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC31/akto.md) | Added |
-| [shiva](https://github.com/DefconParrot/DefconArsenalTools/blob/main/hardening/DC31/shiva.md) | Added |
+| Tool Name                                                                                                                                    | Addition Status: Added / Updated | Category_Added                                                                                          |
+|----------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|---------------------------------------------------------------------------------------------------------|
+| [EDRSandBlast](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC30/EDRSandBlast.md)                               | Added                                | [exploitation](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation)               |
+| [cisco_asa_research](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC30/cisco_asa_research.md)                   | Added                                | [exploitation](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation)               |
+| [emoji_shellcoding](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC30/emoji_shellcoding.md)                     | Added                                | [exploitation](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation)               |
+| [pacman](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC30/pacman.md)                                           | Added                                | [exploitation](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation)               |
+| [powerpwn](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC30/powerpwn.md)                                       | Added                                | [exploitation](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation)               |
+| [FRAK](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC20/FRAK.md)                                                 | Added                                | [frameworks](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks)                   |
+| [TeamFiltration](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC30/TeamFiltration.md)                             | Added                                | [frameworks](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks)                   |
+| [canTot](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC30/canTot.md)                                             | Added                                | [frameworks](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks)                   |
+| [EMBA](https://github.com/DefconParrot/DefconArsenalTools/blob/main/hardening/DC30/EMBA.md)                                                  | Added                                | [hardening](https://github.com/DefconParrot/DefconArsenalTools/blob/main/hardening)                     |
+| [Gatekeyper](https://github.com/DefconParrot/DefconArsenalTools/blob/main/lock_picking/DC26/Gatekeyper.md)                                   | Added                                | [lock_picking](https://github.com/DefconParrot/DefconArsenalTools/blob/main/lock_picking)               |
+| [BULA-Virus](https://github.com/DefconParrot/DefconArsenalTools/blob/main/malware_research/DC30/BULA-Virus.md)                               | Added                                | [malware research](https://github.com/DefconParrot/DefconArsenalTools/blob/main/malware_research)       |
+| [CANalyse](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_attacks/DC30/CANalyse.md)                                    | Added                                | [network attacks](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_attacks)         |
+| [SquarePhish](https://github.com/DefconParrot/DefconArsenalTools/blob/main/phishing/DC30/SquarePhish.md)                                     | Added                                | [phishing](https://github.com/DefconParrot/DefconArsenalTools/blob/main/phishing)                       |
+| [WiGLEBottleV2](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency/DC31/BT-BLE/AppleJuice.md)                      | Added                                | [radio frequency](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency)         |
+| [AppleJuice](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency/DC31/wardriving/RPi4_WigleBottle_v2.md)            | Added                                | [radio frequency](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency)         |
+| [WIFISHARK](<https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency/DC31/802.11 WIFI/WIFISHARK.md>)                    | Added                                | [radio frequency](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency)         |
+| [Veilid](https://github.com/DefconParrot/DefconArsenalTools/blob/main/P2P/DC31/Veilid.md)                                                    | Added                                | [P2P](https://github.com/DefconParrot/DefconArsenalTools/blob/main/P2P)                                 |
+| [Wifydra](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency/DC31/wardriving/The_Wifydra.md)                       | Added                                | [radio frequency](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency)         |
+| [WiGLE Balloon](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency/DC31/wardriving/Wigle_Balloon.md)               | Added                                | [radio frequency](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency)         |
+| [RFparty](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_analysis/DC31/rfparty-xyz.md)                                 | Added                                | [network analysis](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_analysis)       |
+| [CloudRecon](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_analysis/DC31/CloudRecon.md)                               | Added                                | [network analysis](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_analysis)       |
+| [EasyEASM](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC31/EasyEASM.md)                                         | Added                                | [frameworks](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks)                   |
+| [asyauth](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_attacks/DC31/asyauth.md)                                      | Added                                | [network attacks](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_attacks)         |
+| [SpamChannel](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC31/SpamChannel.md)                                 | Added                                | [exploitation](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation)               |
+| [ezviz_lan_rce](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_attacks/DC31/ezviz_lan_rce.md)                          | Added                                | [network attacks](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_attacks)         |
+| [RelocBonus](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC26/RelocBonus.md)                                   | Added                                | [exploitation](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation)               |
+| [NoFilter](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC31/NoFilter.md)                                       | Added                                | [exploitation](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation)               |
+| [ContainYourself](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC31/ContainYourself.md)                         | Added                                | [exploitation](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation)               |
+| [RTV Secure Terminal CTF](https://github.com/DefconParrot/DefconArsenalTools/blob/main/CTF/DC31/RTV_Secure_Terminal_CTF.md)                  | Added                                | [CTF](https://github.com/DefconParrot/DefconArsenalTools/blob/main/CTF)                                 |
+| [Hack to Basics](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC27/Hack%20to%20Basics.md)                         | Added                                | [frameworks](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks)                   |
+| [Starkiller](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC28/Starkiller.md)                                     | Added                                | [frameworks](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks)                   |
+| [Empire](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC30/Empire.md)                                             | Added                                | [frameworks](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks)                   |
+| [Long Live the Empire](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC31/Long_Live_the_Empire.md)                 | Added                                | [frameworks](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks)                   |
+| [Hacking Bluetooth Low Energy Locks](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency/DC24/Hacking_BLE_Locks.md) | Added                                | [radio frequency](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency)         |
+| [CrackMapExec](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_attacks/DC24/CrackMapExec.md)                            | Added                                | [network attacks](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_attacks)         |
+| [OPC-UA](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC31/OPC-UA.md)                                             | Added                                | [frameworks](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks)                   |
+| [git-wild-hunt](https://github.com/DefconParrot/DefconArsenalTools/blob/main/credential_scanning/DC29/git-wild-hunt.md)                      | Added                                | [credential scanning](https://github.com/DefconParrot/DefconArsenalTools/blob/main/credential_scanning) |
+| [Katalina](https://github.com/DefconParrot/DefconArsenalTools/blob/main/malware_research/DC31/Katalina.md)                                   | Added                                | [malware research](https://github.com/DefconParrot/DefconArsenalTools/blob/main/malware_research)       |
+| [Wine_Pairing_with_Malware](https://github.com/DefconParrot/DefconArsenalTools/blob/main/malware_research/DC31/Wine_Pairing_with_Malware.md) | Added                                | [malware research](https://github.com/DefconParrot/DefconArsenalTools/blob/main/malware_research)       |
+| [AceLdr](https://github.com/DefconParrot/DefconArsenalTools/blob/main/Evasion/DC30/AceLdr.md) | Added | [AceLdr](https://github.com/DefconParrot/DefconArsenalTools/blob/main/Evasion)
+| [Ensemble](https://github.com/DefconParrot/DefconArsenalTools/blob/main/Bug%20Bounty/DC31/Ensemble.md) | Added | [Bug Bounty](https://github.com/DefconParrot/DefconArsenalTools/blob/main/Bug%20Bounty) |
+| [BrokenbyDesign](https://github.com/DefconParrot/DefconArsenalTools/blob/main/Cloud/DC30/brokenbydesign-azure.md) | Added | [cloud](https://github.com/DefconParrot/DefconArsenalTools/blob/main/Cloud) |
+| [AzureGoat](https://github.com/DefconParrot/DefconArsenalTools/blob/main/Cloud/DC30/AzureGoat.md) | Added | [cloud](https://github.com/DefconParrot/DefconArsenalTools/blob/main/Cloud) |
+| [BLEMystique](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency/DC26/BLEMystique.md) | Added | [radio frequency](https://github.com/DefconParrot/DefconArsenalTools/blob/main/radio-frequency) |
+| [VoIPShark](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_analysis/DCChina1/VoIPShark.md) | Added | [network analysis](https://github.com/DefconParrot/DefconArsenalTools/blob/main/network_analysis) |
+| [Zfone](https://github.com/DefconParrot/DefconArsenalTools/blob/main/Telephony/DC15/zphone.md) | Added | [telephony](https://github.com/DefconParrot/DefconArsenalTools/blob/main/Telephony) |
+| [guestlist](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation/DC31/guestlist.md) | Added | [exploitation](https://github.com/DefconParrot/DefconArsenalTools/blob/main/exploitation)
+| [FuncoPop](https://github.com/DefconParrot/DefconArsenalTools/blob/main/Cloud/DC31/FuncoPop.md) | Added | [cloud](https://github.com/DefconParrot/DefconArsenalTools/blob/main/Cloud) |
+| [akto](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks/DC31/akto.md) | Added | [frameworks](https://github.com/DefconParrot/DefconArsenalTools/blob/main/frameworks) |
+| [shiva](https://github.com/DefconParrot/DefconArsenalTools/blob/main/hardening/DC31/shiva.md) | Added | [hardening](https://github.com/DefconParrot/DefconArsenalTools/blob/main/hardening) |


### PR DESCRIPTION
- Fixed a broken link to a tool added.
- Added a category for the tools added for a more quick means for users to go directly to the main category or see all tools belonging to the same category, without the need of hovering over a link to identify if it's in the right category.
- Status for a tool whose information has been added should now be **_'updated'_** for easier identification.